### PR TITLE
Fix return order of tensors in _inner method

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -66,7 +66,7 @@ class _PretrainIterableDataset(_IterableDataset):
         X = torch.tensor(input_ids[:-1], dtype=torch.long)
         Y = torch.tensor(input_ids[1:], dtype=torch.long)
         loss_mask = torch.tensor(loss_mask[1:], dtype=torch.long)
-        return loss_mask, X, Y
+        return X, Y, loss_mask
 
 
 class _SFTIterableDataset(_IterableDataset):


### PR DESCRIPTION
Adjust the return order of tensors in the `_inner` method to ensure consistency and correctness in data handling.